### PR TITLE
Update cloudblockstorage.py

### DIFF
--- a/pyrax/cloudblockstorage.py
+++ b/pyrax/cloudblockstorage.py
@@ -29,7 +29,8 @@ from pyrax.resource import BaseResource
 import pyrax.utils as utils
 
 
-MIN_SIZE = 100
+SATA_MIN_SIZE = 75
+SSD_MIN_SIZE = 50
 MAX_SIZE = 1024
 RETRY_INTERVAL = 5
 
@@ -249,12 +250,14 @@ class CloudBlockStorageManager(BaseManager):
         """
         Used to create the dict required to create a new volume
         """
-        if not isinstance(size, (int, long)) or not (
-                MIN_SIZE <= size <= MAX_SIZE):
-            raise exc.InvalidSize("Volume sizes must be integers between "
-                    "%s and %s." % (MIN_SIZE, MAX_SIZE))
         if volume_type is None:
             volume_type = "SATA"
+        if volume_type = "SATA":
+            if not isinstance(size, (int, long)) or not (SATA_MIN_SIZE <= size <= MAX_SIZE):
+                raise exc.InvalidSize("Volume sizes must be integers between ""%s and %s." % (SATA_MIN_SIZE, MAX_SIZE))
+        if volume_type = "SSD":
+            if not isinstance(size, (int, long)) or not (SSD_MIN_SIZE <= size <= MAX_SIZE):
+                raise exc.InvalidSize("Volume sizes must be integers between ""%s and %s." % (SSD_MIN_SIZE, MAX_SIZE))
         if description is None:
             description = ""
         if metadata is None:


### PR DESCRIPTION
Update MIN_SIZE parameter, which is now different between SATA (75GB) and SSD (50GB)
Default volume_type if not specified will be SATA (min 75GB)
If volume_type is SSD MIN_SIZE will be 50GB